### PR TITLE
chore: migrate workflows to artifact branch model (issue #320)

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -3,6 +3,7 @@ name: "Update Configuration and Build"
 on:
   workflow_dispatch:
   push:
+  delete:
 
 jobs:
   update:
@@ -11,8 +12,11 @@ jobs:
     permissions: write-all
 
     steps:
-      - uses: Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata
+      - uses: Meniole/action-deploy-plugin@feat/320-dist-artifact-branches
         with:
+          action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
+          sourceRef: ${{ github.event.ref || github.event.workflow_run.head_branch || github.ref_name }}
+          artifactPrefix: dist/
           treatAsEsm: true
           sourcemap: false
           pluginEntry: "${{ github.workspace }}/src/action.ts"


### PR DESCRIPTION
## Summary
- migrate workflow wiring to the artifact-branch deployment model
- pass explicit `sourceRef` and `artifactPrefix` to deployment actions
- align update/deletion lifecycle with paired `dist/<source-ref>` branches

Closes https://github.com/ubiquity-os/ubiquity-os-kernel/issues/320
